### PR TITLE
Check for chat template before using it

### DIFF
--- a/lib/inference/image_inference_page.dart
+++ b/lib/inference/image_inference_page.dart
@@ -78,7 +78,15 @@ class _ImageInferencePageState extends State<ImageInferencePage>
               return Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  ModelInfo(widget.project, children: const []),
+                  ModelInfo(widget.project, children: [
+                    PropertyItem(
+                      name: "Task",
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: widget.project.tasks.map((task) => PropertyValue(task.name)).toList()
+                      )
+                    ),
+                  ]),
                   (
                     Expanded(
                       child: Padding(

--- a/lib/inference/model_info.dart
+++ b/lib/inference/model_info.dart
@@ -24,13 +24,6 @@ class ModelInfo extends StatelessWidget {
                 child: PropertyValue(project.name)
               ),
               PropertyItem(
-                name: "Task",
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: project.tasks.map((task) => PropertyValue(task.name)).toList()
-                )
-              ),
-              PropertyItem(
                 name: "Architecture",
                 enabled: project.tasks.firstWhereOrNull((t) => t.architecture.isNotEmpty) != null,
                 child: Column(

--- a/lib/inference/text_inference_page.dart
+++ b/lib/inference/text_inference_page.dart
@@ -37,9 +37,6 @@ class _TextInferencePageState extends State<TextInferencePage> with TickerProvid
   @override
   Widget build(BuildContext context) {
     Locale locale = Localizations.localeOf(context);
-    final numberFormatter = NumberFormat.decimalPatternDigits(
-        locale: locale.languageCode, decimalDigits: 2);
-
 
     return ChangeNotifierProxyProvider<PreferenceProvider, TextInferenceProvider>(
       create: (_) {
@@ -71,6 +68,10 @@ class _TextInferencePageState extends State<TextInferencePage> with TickerProvid
                       child: ModelInfo(
                         widget.project,
                         children: [
+                          PropertyItem(
+                            name: "Task",
+                            child: PropertyValue(inference.task),
+                          ),
                           Padding(
                             padding: const EdgeInsets.only(left: 12, top: 12, right: 20.0),
                             child: Column(

--- a/lib/interop/generated_bindings.dart
+++ b/lib/interop/generated_bindings.dart
@@ -421,6 +421,21 @@ class OpenVINO {
   late final _llmInferenceForceStop = _llmInferenceForceStopPtr
       .asFunction<ffi.Pointer<Status> Function(CLLMInference)>();
 
+  ffi.Pointer<StatusOrBool> llmInferenceHasChatTemplate(
+    CLLMInference instance,
+  ) {
+    return _llmInferenceHasChatTemplate(
+      instance,
+    );
+  }
+
+  late final _llmInferenceHasChatTemplatePtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Pointer<StatusOrBool> Function(CLLMInference)>>(
+      'llmInferenceHasChatTemplate');
+  late final _llmInferenceHasChatTemplate = _llmInferenceHasChatTemplatePtr
+      .asFunction<ffi.Pointer<StatusOrBool> Function(CLLMInference)>();
+
   ffi.Pointer<Status> llmInferenceClose(
     CLLMInference instance,
   ) {
@@ -607,6 +622,16 @@ final class StatusOrString extends ffi.Struct {
   external ffi.Pointer<pkg_ffi.Utf8> message;
 
   external ffi.Pointer<pkg_ffi.Utf8> value;
+}
+
+final class StatusOrBool extends ffi.Struct {
+  @ffi.Int()
+  external int status;
+
+  external ffi.Pointer<pkg_ffi.Utf8> message;
+
+  @ffi.Bool()
+  external bool value;
 }
 
 final class StatusOrImageInference extends ffi.Struct {

--- a/lib/providers/text_inference_provider.dart
+++ b/lib/providers/text_inference_provider.dart
@@ -123,6 +123,18 @@ class TextInferenceProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  String get task {
+    if (_inference == null) {
+      return "";
+    }
+
+    if (_inference?.chatEnabled == true) {
+      return "Chat";
+    } else {
+      return "Text Generation";
+    }
+  }
+
   Message? get interimResponse {
     if (_response == null) {
       return null;

--- a/openvino_bindings/src/bindings.cc
+++ b/openvino_bindings/src/bindings.cc
@@ -203,6 +203,16 @@ Status* llmInferenceClearHistory(CLLMInference instance) {
     }
 }
 
+StatusOrBool* llmInferenceHasChatTemplate(CLLMInference instance) {
+    try {
+        bool has_chat_template = reinterpret_cast<LLMInference*>(instance)->has_chat_template();
+        return new StatusOrBool{OkStatus, "", has_chat_template};
+    } catch (...) {
+        auto except = handle_exceptions();
+        return new StatusOrBool{except->status, except->message};
+    }
+}
+
 Status* llmInferenceForceStop(CLLMInference instance) {
     try {
         reinterpret_cast<LLMInference*>(instance)->force_stop();

--- a/openvino_bindings/src/bindings.h
+++ b/openvino_bindings/src/bindings.h
@@ -40,6 +40,12 @@ typedef struct {
 typedef struct {
     enum StatusEnum status;
     const char* message;
+    bool value;
+} StatusOrBool;
+
+typedef struct {
+    enum StatusEnum status;
+    const char* message;
     CImageInference value;
 } StatusOrImageInference;
 
@@ -94,6 +100,7 @@ EXPORT Status* llmInferenceSetListener(CLLMInference instance, LLMInferenceCallb
 EXPORT StatusOrLLMResponse* llmInferencePrompt(CLLMInference instance, const char* message, float temperature, float top_p);
 EXPORT Status* llmInferenceClearHistory(CLLMInference instance);
 EXPORT Status* llmInferenceForceStop(CLLMInference instance);
+EXPORT StatusOrBool* llmInferenceHasChatTemplate(CLLMInference instance);
 EXPORT Status* llmInferenceClose(CLLMInference instance);
 
 EXPORT StatusOrGraphRunner* graphRunnerOpen(const char* graph);

--- a/openvino_bindings/src/llm/llm_inference.h
+++ b/openvino_bindings/src/llm/llm_inference.h
@@ -7,8 +7,6 @@
 #include "openvino/genai/llm_pipeline.hpp"
 #include "metrics.h"
 
-
-
 inline float nan_safe(const float& value){
   if (std::isnan(value)) {
     return 0.0f;
@@ -22,17 +20,18 @@ class LLMInference {
   ov::genai::ChatHistory history;
   std::function<bool(std::string)> streamer;
   public:
-    LLMInference(std::string model_path, std::string device): pipe(model_path, device) {}
+    LLMInference(std::string model_path, std::string device): model_path(model_path), pipe(model_path, device) {}
     void set_streamer(const std::function<void(const std::string& response)> callback);
     std::string prompt(std::string message, float temperature, float top_p);
     void clear_history();
     void force_stop();
-
+    bool has_chat_template();
     Metrics get_metrics();
 
     std::optional<ov::genai::PerfMetrics> metrics = {};
   private:
     bool _stop = false;
+    std::string model_path;
 
 
 };


### PR DESCRIPTION
Not all models are trained for chat.
In order to facilitate the pure "text generation" models we pass through the prompt without chat history.
For the GUI we do still show it as chat however but in the model info you can see either chat or Text generation.

Added a binding call to check if the chat template. Not sure if this is the correct approach