### PR TITLE
Fixes crash due to streamer continueing after forceStop

### DIFF
--- a/lib/providers/text_inference_provider.dart
+++ b/lib/providers/text_inference_provider.dart
@@ -97,7 +97,9 @@ class TextInferenceProvider extends ChangeNotifier {
        _response = _response! + word;
      }
      _speed = averageElapsed;
-     notifyListeners();
+     if (hasListeners) {
+       notifyListeners();
+     }
      stopWatch.start();
      n++;
   }
@@ -160,7 +162,9 @@ class TextInferenceProvider extends ChangeNotifier {
     }
     _response = null;
     n = 0;
-    notifyListeners();
+    if (hasListeners) {
+      notifyListeners();
+    }
   }
 
   void close() {

--- a/openvino_bindings/src/llm/llm_inference.cc
+++ b/openvino_bindings/src/llm/llm_inference.cc
@@ -1,3 +1,4 @@
+#include <condition_variable>
 #include <fstream>
 #include <nlohmann/json.hpp>
 
@@ -7,6 +8,9 @@
 void LLMInference::set_streamer(const std::function<void(const std::string& response)> callback) {
     streamer = [callback, this](std::string word) {
         if (_stop) {
+            _done = true;
+            streamer_lock.unlock();
+            cond.notify_all();
             return true;
         }
         callback(word.c_str());
@@ -28,12 +32,17 @@ std::string LLMInference::prompt(std::string message, float temperature, float t
     config.top_p = top_p;
     ov::genai::DecodedResults result;
 
+    _done = false;
     if (streamer) {
+        streamer_lock.lock();
         result = pipe.generate(prompt, config, streamer);
+        streamer_lock.unlock();
+        cond.notify_all();
         history.push_back({{"role", "assistant"}, {"content", result}});
     } else {
         result = pipe.generate(prompt, config);
     }
+    _done = true;
 
     if (metrics.has_value()) {
         metrics = metrics.value() + result.perf_metrics;
@@ -51,6 +60,10 @@ void LLMInference::clear_history() {
 
 void LLMInference::force_stop() {
     _stop = true;
+    std::unique_lock<std::mutex> lock(streamer_lock);
+    while(!_done) {
+        cond.wait(lock);
+    }
 }
 
 Metrics LLMInference::get_metrics() {

--- a/openvino_bindings/src/llm/llm_inference.h
+++ b/openvino_bindings/src/llm/llm_inference.h
@@ -3,7 +3,7 @@
 
 #include <optional>
 #include <cmath>
-
+#include <mutex>
 #include "openvino/genai/llm_pipeline.hpp"
 #include "metrics.h"
 
@@ -20,7 +20,9 @@ class LLMInference {
   ov::genai::ChatHistory history;
   std::function<bool(std::string)> streamer;
   public:
-    LLMInference(std::string model_path, std::string device): model_path(model_path), pipe(model_path, device) {}
+    LLMInference(std::string model_path, std::string device):
+      model_path(model_path),
+      pipe(model_path, device) {}
     void set_streamer(const std::function<void(const std::string& response)> callback);
     std::string prompt(std::string message, float temperature, float top_p);
     void clear_history();
@@ -32,8 +34,9 @@ class LLMInference {
   private:
     bool _stop = false;
     std::string model_path;
-
-
+    std::mutex streamer_lock;
+    std::condition_variable cond;
+    bool _done = true;
 };
 
 


### PR DESCRIPTION
The idea is that forceStop waits for the streamer to continue. This is done using a mutex which is locked when prompt is busy LLMPipeline doesnt allow multiple prompts at same time so we good.