### PR TITLE
Fix overflow for model card on models page in windows

### DIFF
--- a/lib/pages/models/widgets/model_list.dart
+++ b/lib/pages/models/widgets/model_list.dart
@@ -41,8 +41,8 @@ class ModelList extends StatelessWidget {
                       child: Consumer<ProjectProvider>(builder: (context, projectProvider, child) {
                         final filtered = filter.applyFilter(projectProvider.projects);
                         return FixedGrid(
-                          tileWidth: 240,
-                          spacing: 24,
+                          tileWidth: 268,
+                          spacing: 36,
                           itemCount: filtered.length,
                           itemBuilder: (context, index) {
                             return ModelCard(project: filtered[index]);


### PR DESCRIPTION
For some reason it was overflowing on windows. Fixed it by giving it the same proportions as the model card on home page