### PR TITLE
Disable clear and reset button in LLM

### DIFF
--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -222,7 +222,10 @@ class _PlaygroundState extends State<Playground> {
                                   padding: const EdgeInsets.only(bottom: 20),
                                   child: Tooltip(
                                     message: "Create new thread",
-                                    child: Button(child: const Icon(FluentIcons.rocket, size: 18,), onPressed: () { provider.reset(); }),
+                                    child: Button(
+                                      onPressed: provider.interimResponse == null ? () => provider.reset() : null,
+                                      child: const Icon(FluentIcons.rocket, size: 18),
+                                    ),
                                   ),
                                 ),
                                 Expanded(
@@ -266,16 +269,16 @@ class _PlaygroundState extends State<Playground> {
                                 ),
                                 Padding(
                                   padding: const EdgeInsets.only(bottom: 20),
-                                  child: Builder(builder: (context) => provider.interimResponse != null
-                                    ? Tooltip(
-                                      message: "Stop",
-                                      child: Button(child: const Icon(FluentIcons.stop, size: 18,), onPressed: () { provider.forceStop(); }),
-                                    )
-                                    : Tooltip(
+                                  child: Builder(builder: (context) {
+                                    final isRunning = provider.interimResponse != null;
+                                    return Tooltip(
                                       message: "Send message",
-                                      child: Button(child: const Icon(FluentIcons.send, size: 18,), onPressed: () { message(_textController.text); }),
-                                    )
-                                  ),
+                                      child: Button(
+                                        onPressed: isRunning ?  null : () => message(_textController.text),
+                                        child: const Icon(FluentIcons.send, size: 18),
+                                      ),
+                                    );
+                                  }),
                                 )
                               ]
                             ),

--- a/lib/providers/text_inference_provider.dart
+++ b/lib/providers/text_inference_provider.dart
@@ -188,7 +188,6 @@ class TextInferenceProvider extends ChangeNotifier {
   }
 
   void reset() {
-    //_inference?.close();
     _inference?.forceStop();
     _inference?.clearHistory();
     _messages.clear();


### PR DESCRIPTION
Due to bug in GenAI we cannot stop an LLM in progress to prevent the user from crashing the process as a result this commit disables the buttons when the response is in progress.

It's ugly, but it might all we can do until OV 2025.0