### PR TITLE
update open-pull-requests-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
+    # Limit number of open PRs to 0 so that we only get security updates
+    # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
+    open-pull-requests-limit: 0
     directory: /
     schedule:
       interval: weekly
@@ -12,6 +15,6 @@ updates:
 
   - package-ecosystem: pub
     directory: /
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     schedule:
       interval: weekly


### PR DESCRIPTION
This PR limits number of open Dependabot PRs to 0 so that we only get security updates
See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates