### PR TITLE
Move LLM Options to expander

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,7 +11,7 @@ include: package:flutter_lints/flutter.yaml
 
 analyzer:
   exclude:
-    - openvino_bindings/bazel-*
+    - openvino_bindings
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -102,30 +102,34 @@ class _PlaygroundState extends State<Playground> {
               SizedBox(
                 height: 64,
                 child: GridContainer(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: const DeviceSelector()
+                    child: const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: DeviceSelector()
                     ),
-                  ),
                 ),
+              ),
              Expanded(child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: theme.brightness.isDark ? backgroundColor.dark : theme.scaffoldBackgroundColor
                 ),
-               child: GridContainer(child: SizedBox(
-                width: double.infinity,
-                child: Builder(builder: (context) {
-                  if (!provider.initialized) {
-                    return const Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        SizedBox(width: 64,height: 64, child: ProgressRing()),
-                        Padding(
-                          padding: EdgeInsets.only(top: 18),
-                          child: Text("Loading model..."),
-                        )
-                      ],
-                    );
+                child: GridContainer(child: SizedBox(
+                  width: double.infinity,
+                  child: Builder(builder: (context) {
+                    if (!provider.initialized) {
+                      return const Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          SizedBox(
+                            width: 64,
+                            height: 64,
+                            child: ProgressRing()
+                          ),
+                          Padding(
+                            padding: EdgeInsets.only(top: 18),
+                            child: Text("Loading model..."),
+                          )
+                        ],
+                      );
                   }
                   return Column(
                     children: [

--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/services.dart';
+import 'package:inference/pages/text_generation/widgets/llm_options.dart';
 import 'package:inference/widgets/grid_container.dart';
 import 'package:inference/pages/text_generation/widgets/assistant_message.dart';
 import 'package:inference/pages/text_generation/widgets/model_properties.dart';
@@ -99,14 +100,26 @@ class _PlaygroundState extends State<Playground> {
         Consumer<TextInferenceProvider>(builder: (context, provider, child) =>
           Expanded(child: Column(
             children: [
-              SizedBox(
-                height: 64,
-                child: GridContainer(
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 16),
-                      child: DeviceSelector()
-                    ),
+              Expander(
+                icon: Row(
+                  children: const [
+                      Padding(
+                        padding: EdgeInsets.only(right: 8),
+                        child: Text("Options"),
+                      ),
+                      Icon(FluentIcons.settings),
+                  ]
                 ),
+                header: SizedBox(
+                  height: 64,
+                  child: GridContainer(
+                      child: const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16),
+                        child: DeviceSelector()
+                      ),
+                  ),
+                ),
+                content: LLMOptions(provider),
               ),
              Expanded(child: DecoratedBox(
                 decoration: BoxDecoration(

--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -89,9 +89,6 @@ class _PlaygroundState extends State<Playground> {
 
   @override
   Widget build(BuildContext context) {
-    Locale locale = Localizations.localeOf(context);
-    final nf = NumberFormat.decimalPatternDigits(
-      locale: locale.languageCode, decimalDigits: 2);
     final theme = FluentTheme.of(context);
 
     return Row(
@@ -109,8 +106,8 @@ class _PlaygroundState extends State<Playground> {
                   side: BorderSide.none,
                   borderRadius: BorderRadius.zero,
                 ),
-                icon: Row(
-                  children: const [
+                icon: const Row(
+                  children: [
                       Padding(
                         padding: EdgeInsets.only(right: 8),
                         child: Text("Options"),
@@ -118,10 +115,10 @@ class _PlaygroundState extends State<Playground> {
                       Icon(FluentIcons.settings),
                   ]
                 ),
-                header: SizedBox(
+                header: const SizedBox(
                   height: 64,
                   child: GridContainer(
-                      child: const Padding(
+                      child: Padding(
                         padding: EdgeInsets.symmetric(horizontal: 16),
                         child: DeviceSelector()
                       ),

--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -140,48 +140,25 @@ class _PlaygroundState extends State<Playground> {
                               child: Text("Start chatting with ${provider.project?.name ?? "the model"}!"),
                             );
                           }
-                          return Stack(
-                            alignment: Alignment.bottomCenter,
-                            children: [
-                              SingleChildScrollView(
-                                controller: _scrollController,
-                                child: Padding(padding: const EdgeInsets.symmetric(horizontal: 64, vertical: 20), child: SelectionArea(
-                                  child: SelectionArea(
-                                    child: Column(
-                                      children: provider.messages.map((message) { switch (message.speaker) {
-                                        case Speaker.user: return Padding(
-                                          padding: const EdgeInsets.only(left: 42),
-                                          child: UserMessage(message),
-                                        );
-                                        case Speaker.system: return Text('System: ${message.message}');
-                                        case Speaker.assistant: return AssistantMessage(message);
-                                      }}).toList(),
+                          return SingleChildScrollView(
+                            controller: _scrollController,
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 64, vertical: 20),
+                              child: SelectionArea(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                                  children: provider.messages.map((message) => switch (message.speaker) {
+                                    Speaker.user => Padding(
+                                      padding: const EdgeInsets.only(left: 42),
+                                      child: UserMessage(message),
                                     ),
-                                  ),
-                                ),),
-                              ),
-                              Positioned(
-                                bottom: 10,
-                                child: Builder(builder: (context) => attachedToBottom
-                                  ? const SizedBox()
-                                  : Padding(
-                                    padding: const EdgeInsets.only(top:2),
-                                    child: FilledButton(child: const Row(
-                                      children: [
-                                        Icon(FluentIcons.chevron_down, size: 12),
-                                        SizedBox(width: 4),
-                                        Text('Scroll to bottom'),
-                                      ],
-                                    ), onPressed: () {
-                                      jumpToBottom();
-                                      setState(() {
-                                        attachedToBottom = true;
-                                      });
-                                    }),
-                                  )
+                                    Speaker.system => Text('System: ${message.message}'),
+                                    Speaker.assistant => AssistantMessage(message)
+                                  }).toList(),
                                 ),
-                              )
-                            ],
+                              ),
+                            ),
                           );
                         }),
                       ),

--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -101,6 +101,14 @@ class _PlaygroundState extends State<Playground> {
           Expanded(child: Column(
             children: [
               Expander(
+                headerShape: (_) => const RoundedRectangleBorder(
+                  side: BorderSide.none,
+                  borderRadius: BorderRadius.zero,
+                ),
+                contentShape: (_) => const RoundedRectangleBorder(
+                  side: BorderSide.none,
+                  borderRadius: BorderRadius.zero,
+                ),
                 icon: Row(
                   children: const [
                       Padding(

--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -104,38 +104,7 @@ class _PlaygroundState extends State<Playground> {
                 child: GridContainer(
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Row(
-                          children: [
-                            const DeviceSelector(),
-                            const Divider(size: 24,direction: Axis.vertical,),
-                            const SizedBox(width: 24,),
-                            const Text('Temperature '),
-                            Tooltip(
-                              message: 'Temperature controls the randomness of the output. Higher values mean more random outputs.',
-                              child: Icon(FluentIcons.info, size: 16, color: subtleTextColor.of(theme),),
-                            ),
-                            Slider(
-                              value: provider.temperature,
-                              onChanged: (value) { provider.temperature = value; },
-                              label: nf.format(provider.temperature),
-                              min: 0.1,
-                              max: 2.0,
-                            ),
-                            const SizedBox(width: 24,),
-                            const Text('Top P '),
-                            Tooltip(
-                              message: 'Top P controls the diversity of the output by limiting the selection to a subset of the most probable tokens.',
-                              child: Icon(FluentIcons.info, size: 16, color: subtleTextColor.of(theme)),
-                            ),
-                            Slider(
-                              value: provider.topP,
-                              onChanged: (value) { provider.topP = value; },
-                              label: nf.format(provider.topP),
-                              max: 1.0,
-                              min: 0.1,
-                            ),
-                          ],
-                  )
+                      child: const DeviceSelector()
                     ),
                   ),
                 ),

--- a/lib/pages/text_generation/playground.dart
+++ b/lib/pages/text_generation/playground.dart
@@ -15,7 +15,6 @@ import 'package:inference/project.dart';
 import 'package:inference/providers/text_inference_provider.dart';
 import 'package:inference/theme_fluent.dart';
 import 'package:inference/widgets/device_selector.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class Playground extends StatefulWidget {

--- a/lib/pages/text_generation/widgets/assistant_message.dart
+++ b/lib/pages/text_generation/widgets/assistant_message.dart
@@ -24,66 +24,45 @@ class _AssistantMessageState extends State<AssistantMessage> {
 
   @override
   Widget build(BuildContext context) {
-    Locale locale = Localizations.localeOf(context);
-    final nf = NumberFormat.decimalPatternDigits(
-        locale: locale.languageCode, decimalDigits: 0);
     final theme = FluentTheme.of(context);
     final backgroundColor = theme.brightness.isDark
      ? theme.scaffoldBackgroundColor
      : const Color(0xFFF5F5F5);
 
     return Consumer<TextInferenceProvider>(builder: (context, inferenceProvider, child) =>
-      Align(
-        child: Padding(
-          padding: const EdgeInsets.only(bottom: 8),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(right: 10, top: 20),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(16.0),
-                  child: Container(
-                    width: 32,
-                    height: 32,
-                    decoration: BoxDecoration(
-                      image: DecorationImage(
-                        image: inferenceProvider.project!.thumbnailImage(),
-                        fit: BoxFit.cover,
-                      ),
+      Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(right: 10, top: 20),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(16.0),
+                child: Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    image: DecorationImage(
+                      image: inferenceProvider.project!.thumbnailImage(),
+                      fit: BoxFit.cover,
                     ),
                   ),
                 ),
               ),
-              Column(
+            ),
+            Expanded(
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 4),
-                    child: SelectionContainer.disabled(
-                      child: Row(
-                        children: [
-                          Text(
-                            inferenceProvider.project!.name,
-                            style:  TextStyle(
-                              color: subtleTextColor.of(theme),
-                            ),
-                          ),
-                          if (widget.message.time != null) Text(
-                            DateFormat(' | yyyy-MM-dd HH:mm:ss').format(widget.message.time!),
-                            style:  TextStyle(
-                              color: subtleTextColor.of(theme),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
+                  MessageHeader(
+                    agentName: inferenceProvider.project?.name,
+                    timestamp: widget.message.time,
                   ),
                   MouseRegion(
                     onEnter: (_) => setState(() { _hovering = true; }),
                     onExit: (_) => setState(() { _hovering = false; }),
                     child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
                         Container(
                           constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 502),
@@ -103,79 +82,137 @@ class _AssistantMessageState extends State<AssistantMessage> {
                           ),
                         ),
                         if (_hovering)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 4),
-                            child: SelectionContainer.disabled(
-                              child: Row(
-                                children: [
-                                  if (widget.message.metrics != null) Padding(
-                                    padding: const EdgeInsets.only(right: 8),
-                                    child: Tooltip(
-                                      message: 'Time to first token',
-                                      child: Text(
-                                        'TTF: ${nf.format(widget.message.metrics!.ttft)}ms',
-                                        style:  TextStyle(
-                                          fontSize: 12,
-                                          color: subtleTextColor.of(theme),
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  if (widget.message.metrics != null) Padding(
-                                    padding: const EdgeInsets.only(right: 8),
-                                    child: Tooltip(
-                                      message: 'Time per output token',
-                                      child: Text(
-                                        'TPOT: ${nf.format(widget.message.metrics!.tpot)}ms',
-                                        style:  TextStyle(
-                                          fontSize: 12,
-                                          color: subtleTextColor.of(theme),
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  if (widget.message.metrics != null) Padding(
-                                    padding: const EdgeInsets.only(right: 8),
-                                    child: Tooltip(
-                                      message: 'Generate total duration',
-                                      child: Text(
-                                        'Generate: ${nf.format(widget.message.metrics!.generate_time/1000)}s',
-                                        style:  TextStyle(
-                                          fontSize: 12,
-                                          color: subtleTextColor.of(theme),
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  IconButton(
-                                    icon: const Icon(FluentIcons.copy),
-                                    onPressed: () async{
-                                      await displayInfoBar(context, builder: (context, close) =>
-                                        InfoBar(
-                                          title: const Text('Copied to clipboard'),
-                                          severity: InfoBarSeverity.info,
-                                          action: IconButton(
-                                            icon: const Icon(FluentIcons.clear),
-                                            onPressed: close,
-                                          ),
-                                        ),
-                                      );
-                                      Clipboard.setData(ClipboardData(text: widget.message.message));
-                                    },
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ) else const SizedBox(height: 34)
+                          MessageMiscellanious(message: widget.message)
+                        else
+                          const SizedBox(height: 34)
+
                       ],
                     ),
                   ),
+
                 ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
+}
+
+
+class MessageHeader extends StatelessWidget {
+
+  final String? agentName;
+  final DateTime? timestamp;
+  const MessageHeader({super.key, this.agentName, this.timestamp});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: SelectionContainer.disabled(
+        child: Row(
+          children: [
+            if (agentName != null) Text(
+              agentName!,
+              style:  TextStyle(
+                color: subtleTextColor.of(theme),
+              ),
+            ),
+            if (timestamp != null) Text(
+              DateFormat(' | yyyy-MM-dd HH:mm:ss').format(timestamp!),
+              style:  TextStyle(
+                color: subtleTextColor.of(theme),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+}
+
+
+class MessageMiscellanious extends StatelessWidget {
+  final Message message;
+
+  const MessageMiscellanious({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    Locale locale = Localizations.localeOf(context);
+    final nf = NumberFormat.decimalPatternDigits(
+        locale: locale.languageCode, decimalDigits: 0);
+    final theme = FluentTheme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: SelectionContainer.disabled(
+        child: Row(
+          children: [
+            if (message.metrics != null) Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Tooltip(
+                message: 'Time to first token',
+                child: Text(
+                  'TTF: ${nf.format(message.metrics!.ttft)}ms',
+                  style:  TextStyle(
+                    fontSize: 12,
+                    color: subtleTextColor.of(theme),
+                  ),
+                ),
+              ),
+            ),
+            if (message.metrics != null) Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Tooltip(
+                message: 'Time per output token',
+                child: Text(
+                  'TPOT: ${nf.format(message.metrics!.tpot)}ms',
+                  style:  TextStyle(
+                    fontSize: 12,
+                    color: subtleTextColor.of(theme),
+                  ),
+                ),
+              ),
+            ),
+            if (message.metrics != null) Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Tooltip(
+                message: 'Generate total duration',
+                child: Text(
+                  'Generate: ${nf.format(message.metrics!.generate_time/1000)}s',
+                  style:  TextStyle(
+                    fontSize: 12,
+                    color: subtleTextColor.of(theme),
+                  ),
+                ),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(FluentIcons.copy),
+              onPressed: () async{
+                await displayInfoBar(context, builder: (context, close) =>
+                  InfoBar(
+                    title: const Text('Copied to clipboard'),
+                    severity: InfoBarSeverity.info,
+                    action: IconButton(
+                      icon: const Icon(FluentIcons.clear),
+                      onPressed: close,
+                    ),
+                  ),
+                );
+                Clipboard.setData(ClipboardData(text: message.message));
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
 }

--- a/lib/pages/text_generation/widgets/llm_options.dart
+++ b/lib/pages/text_generation/widgets/llm_options.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2024 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:inference/providers/text_inference_provider.dart';
+import 'package:inference/theme_fluent.dart';
+import 'package:intl/intl.dart';
+
+class LLMOptions extends StatelessWidget {
+  final TextInferenceProvider provider;
+  const LLMOptions(this.provider, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Locale locale = Localizations.localeOf(context);
+    final nf = NumberFormat.decimalPatternDigits(
+      locale: locale.languageCode, decimalDigits: 2);
+    final theme = FluentTheme.of(context);
+
+    return Row(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Row(
+            children: [
+              const Text("Temperature: "),
+              Tooltip(
+                message: 'Temperature controls the randomness of the output. Higher values mean more random outputs.',
+                child: Icon(FluentIcons.info, size: 16, color: subtleTextColor.of(theme),),
+              ),
+              Slider(
+                value: provider.temperature,
+                onChanged: (value) { provider.temperature = value; },
+                label: nf.format(provider.temperature),
+                max: 1.0,
+                min: 0.1,
+              )
+            ]
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Row(
+            children: [
+              const Text("Top P: "),
+              Tooltip(
+                message: 'Top P controls the diversity of the output by limiting the selection to a subset of the most probable tokens.',
+                child: Icon(FluentIcons.info, size: 16, color: subtleTextColor.of(theme)),
+              ),
+              Slider(
+                value: provider.topP,
+                onChanged: (value) { provider.topP = value; },
+                label: nf.format(provider.topP),
+                max: 2.0,
+                min: 0.1,
+              )
+            ]
+          ),
+        )
+      ]
+    );
+  }
+
+}

--- a/lib/pages/text_generation/widgets/model_properties.dart
+++ b/lib/pages/text_generation/widgets/model_properties.dart
@@ -22,7 +22,7 @@ class ModelProperties extends StatelessWidget {
 
     return Consumer<TextInferenceProvider>(builder: (context, inference, child) {
       return SizedBox(
-        width: 280,
+        width: 310,
         child: GridContainer(
           padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 24),
           child: Column(

--- a/lib/pages/text_generation/widgets/model_properties.dart
+++ b/lib/pages/text_generation/widgets/model_properties.dart
@@ -22,7 +22,7 @@ class ModelProperties extends StatelessWidget {
 
     return Consumer<TextInferenceProvider>(builder: (context, inference, child) {
       return SizedBox(
-        width: 310,
+        width: 280,
         child: GridContainer(
           padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 24),
           child: Column(
@@ -45,26 +45,14 @@ class ModelProperties extends StatelessWidget {
                       value: inference.project!.architecture,
                     ),
                     ModelProperty(
-                      title: "Temperature: ${nf.format(inference.temperature)}",
+                      title: "Temperature",
                       description: "Temperature controls the randomness of the output. Higher values mean more random outputs.",
-                      child: Slider(
-                        value: inference.temperature,
-                        onChanged: (value) { inference.temperature = value; },
-                        label: nf.format(inference.temperature),
-                        max: 1.0,
-                        min: 0.1,
-                      ),
+                      value: nf.format(inference.temperature),
                     ),
                     ModelProperty(
-                      title: "Top P: ${nf.format(inference.topP)}",
+                      title: "Top P",
                       description: "Top P controls the diversity of the output by limiting the selection to a subset of the most probable tokens.",
-                      child: Slider(
-                        value: inference.topP,
-                        onChanged: (value) { inference.topP = value; },
-                        label: nf.format(inference.topP),
-                        max: 2.0,
-                        min: 0.1,
-                      ),
+                      value: nf.format(inference.topP),
                     ),
                     if (inference.project!.isPublic) Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/text_generation/widgets/model_properties.dart
+++ b/lib/pages/text_generation/widgets/model_properties.dart
@@ -45,14 +45,26 @@ class ModelProperties extends StatelessWidget {
                       value: inference.project!.architecture,
                     ),
                     ModelProperty(
-                      title: "Temperature",
+                      title: "Temperature: ${nf.format(inference.temperature)}",
                       description: "Temperature controls the randomness of the output. Higher values mean more random outputs.",
-                      value: nf.format(inference.temperature),
+                      child: Slider(
+                        value: inference.temperature,
+                        onChanged: (value) { inference.temperature = value; },
+                        label: nf.format(inference.temperature),
+                        max: 1.0,
+                        min: 0.1,
+                      ),
                     ),
                     ModelProperty(
-                      title: "Top P",
+                      title: "Top P: ${nf.format(inference.topP)}",
                       description: "Top P controls the diversity of the output by limiting the selection to a subset of the most probable tokens.",
-                      value: nf.format(inference.topP),
+                      child: Slider(
+                        value: inference.topP,
+                        onChanged: (value) { inference.topP = value; },
+                        label: nf.format(inference.topP),
+                        max: 2.0,
+                        min: 0.1,
+                      ),
                     ),
                     if (inference.project!.isPublic) Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/providers/text_inference_provider.dart
+++ b/lib/providers/text_inference_provider.dart
@@ -66,7 +66,7 @@ class TextInferenceProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  LLMInference? _inference;
+  LLMInference? inference;
   final stopWatch = Stopwatch();
   int n = 0;
 
@@ -77,7 +77,7 @@ class TextInferenceProvider extends ChangeNotifier {
 
   Future<void> loadModel() async {
     if (project != null && device != null) {
-      _inference = await LLMInference.init(project!.storagePath, device!)
+      inference = await LLMInference.init(project!.storagePath, device!)
         ..setListener(onMessage);
       loaded.complete();
       notifyListeners();
@@ -127,11 +127,11 @@ class TextInferenceProvider extends ChangeNotifier {
   }
 
   String get task {
-    if (_inference == null) {
+    if (inference == null) {
       return "";
     }
 
-    if (_inference?.chatEnabled == true) {
+    if (inference?.chatEnabled == true) {
       return "Chat";
     } else {
       return "Text Generation";
@@ -156,7 +156,7 @@ class TextInferenceProvider extends ChangeNotifier {
     _response = "...";
     _messages.add(Message(Speaker.user, message, null, DateTime.now()));
     notifyListeners();
-    final response = await _inference!.prompt(message, temperature, topP);
+    final response = await inference!.prompt(message, temperature, topP);
 
     if (_messages.isNotEmpty) {
       _messages.add(Message(Speaker.assistant, response.content, response.metrics, DateTime.now()));
@@ -170,15 +170,15 @@ class TextInferenceProvider extends ChangeNotifier {
 
   void close() {
     _messages.clear();
-    _inference?.close();
+    inference?.close();
     _response = null;
-    if (_inference != null) {
-      _inference!.close();
+    if (inference != null) {
+      inference!.close();
     }
   }
 
   void forceStop() {
-    _inference?.forceStop();
+    inference?.forceStop();
     if (_response != '...') {
       _messages.add(Message(Speaker.assistant, _response!, null, DateTime.now()));
     }
@@ -189,8 +189,8 @@ class TextInferenceProvider extends ChangeNotifier {
   }
 
   void reset() {
-    _inference?.forceStop();
-    _inference?.clearHistory();
+    inference?.forceStop();
+    inference?.clearHistory();
     _messages.clear();
     _response = null;
     notifyListeners();
@@ -199,8 +199,8 @@ class TextInferenceProvider extends ChangeNotifier {
 
   @override
   void dispose() {
-    if (_inference != null) {
-      _inference?.close();
+    if (inference != null) {
+      inference?.close();
       super.dispose();
     } else {
       close();

--- a/lib/widgets/model_propery.dart
+++ b/lib/widgets/model_propery.dart
@@ -7,14 +7,16 @@ import 'package:inference/theme_fluent.dart';
 
 class ModelProperty extends StatelessWidget {
   final String title;
-  final String value;
+  final String? value;
   final String? description;
+  final Widget? child;
 
   const ModelProperty({
       super.key,
       required this.title,
-      required this.value,
+      this.value,
       this.description,
+      this.child,
     });
 
   @override
@@ -31,6 +33,7 @@ class ModelProperty extends StatelessWidget {
               fontWeight: FontWeight.w600,
               fontSize: 14,
             )),
+
             if (description != null && description!.isNotEmpty) ...[
               const SizedBox(width: 4),
               Tooltip(
@@ -44,13 +47,17 @@ class ModelProperty extends StatelessWidget {
             ],
           ],),
         ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 16),
-          child: Text(value, style: TextStyle(
-              fontSize: 16,
-              color: subtleTextColor.of(theme),
-          )),
-        ),
+        if (value != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 16),
+            child: Text(value!, style: TextStyle(
+                fontSize: 16,
+                color: subtleTextColor.of(theme),
+            )),
+          ),
+
+        if (child != null)
+          child!
       ]
     );
   }

--- a/test/fixtures.dart
+++ b/test/fixtures.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:inference/project.dart';
+
+Project largeLanguageModel() {
+  return PublicProject(
+    "test_id", "llm-model", "1.0.0", "TinyLlama", "2024-04-25T19:16:51.714000+00:00", ProjectType.text, "/dev/null", Image.asset("images/model_thumbnails/llama.jpg"), null
+  )
+  ..tasks.add(Task("task_id", "LLM", "LLM", [], null, [], "LLamaForCasualLM","int8"));
+}

--- a/test/pages/text_generation/playground_test.dart
+++ b/test/pages/text_generation/playground_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2024 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:async';
+
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inference/interop/device.dart' show Device;
+import 'package:inference/interop/llm_inference.dart';
+import 'package:inference/interop/openvino_bindings.dart' show ModelResponse, Metrics;
+import 'package:inference/pages/text_generation/playground.dart';
+import 'package:inference/project.dart';
+import 'package:inference/providers/preference_provider.dart';
+import 'package:inference/providers/text_inference_provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+
+import '../../fixtures.dart';
+
+
+class MockLLMInference extends Mock implements LLMInference {}
+
+Widget renderWidget(TextInferenceProvider textInferenceProvider, PreferenceProvider preferences, Project project) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider.value(
+        value: preferences,
+      ),
+      ChangeNotifierProvider.value(
+        value: textInferenceProvider,
+      ),
+    ],
+    child: FluentApp(
+      home: ScaffoldPage(
+        content: Playground(project: project)
+      )
+    ),
+  );
+}
+
+PreferenceProvider get preferenceProvider {
+    final preferences = PreferenceProvider("AUTO");
+    PreferenceProvider.availableDevices = const [Device("AUTO","auto"), Device("CPU", "Test CPU")];
+    return preferences;
+}
+
+main() {
+  late MockLLMInference inference;
+
+  setUpAll(() {
+    inference = MockLLMInference();
+  });
+  //testWidgets('test something', (tester) async {
+  //  final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
+  //  provider.inference = inference;
+  //  provider.loaded.complete();
+
+  //  final completer = Completer<void>();
+
+  //  final metrics = calloc<Metrics>();
+  //  when(() => inference.prompt(any(), any(), any())).thenAnswer((_) async {
+  //    await completer.future;
+  //    return ModelResponse("The color of the sun is yellow", metrics.ref);
+
+  //  });
+
+  //  await tester.pumpWidget(renderWidget(provider, preferenceProvider, largeLanguageModel()));
+
+  //  await tester.enterText(find.byType(TextBox), 'What is the color of the sun?');
+
+
+
+  //  calloc.free(metrics);
+  //});
+
+
+}

--- a/test/pages/text_generation/playground_test.dart
+++ b/test/pages/text_generation/playground_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'dart:ffi';
+import 'dart:ffi' as ffi;
 import 'package:ffi/ffi.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -68,7 +68,7 @@ main() {
       return ModelResponse("The color of the sun is yellow", metrics.ref);
 
     });
-
+    await tester.binding.setSurfaceSize(const Size(1900, 1024));
     await tester.pumpWidget(renderWidget(provider, preferenceProvider, largeLanguageModel()));
 
     await tester.enterText(find.byType(TextBox), 'What is the color of the sun?');
@@ -84,7 +84,9 @@ main() {
     expect(find.text('The color of the sun is yellow'), findsOneWidget);
 
     calloc.free(metrics);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
   });
+
 
   testWidgets('test chat reset clears chat', (tester) async {
     final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
@@ -95,6 +97,7 @@ main() {
       return ModelResponse("The color of the sun is yellow", metrics.ref);
     });
 
+    await tester.binding.setSurfaceSize(const Size(1900, 1024));
     await tester.pumpWidget(renderWidget(provider, preferenceProvider, largeLanguageModel()));
     await tester.enterText(find.byType(TextBox), 'What is the color of the sun?');
     await tester.tap(find.byIcon(FluentIcons.send));
@@ -107,6 +110,7 @@ main() {
     expect(provider.messages, isEmpty);
 
     calloc.free(metrics);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
   });
 
 

--- a/test/pages/text_generation/playground_test.dart
+++ b/test/pages/text_generation/playground_test.dart
@@ -53,28 +53,41 @@ main() {
   setUpAll(() {
     inference = MockLLMInference();
   });
-  //testWidgets('test something', (tester) async {
-  //  final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
-  //  provider.inference = inference;
-  //  provider.loaded.complete();
 
-  //  final completer = Completer<void>();
+  testWidgets('test chat with large language model', (tester) async {
+    final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
+    provider.inference = inference;
+    provider.loaded.complete();
 
-  //  final metrics = calloc<Metrics>();
-  //  when(() => inference.prompt(any(), any(), any())).thenAnswer((_) async {
-  //    await completer.future;
-  //    return ModelResponse("The color of the sun is yellow", metrics.ref);
+    final completer = Completer<void>();
 
-  //  });
+    final metrics = calloc<Metrics>();
+    when(() => inference.prompt(any(), any(), any())).thenAnswer((_) async {
+      await completer.future;
+      return ModelResponse("The color of the sun is yellow", metrics.ref);
 
-  //  await tester.pumpWidget(renderWidget(provider, preferenceProvider, largeLanguageModel()));
+    });
 
-  //  await tester.enterText(find.byType(TextBox), 'What is the color of the sun?');
+    await tester.pumpWidget(renderWidget(provider, preferenceProvider, largeLanguageModel()));
+
+    await tester.enterText(find.byType(TextBox), 'What is the color of the sun?');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(FluentIcons.send));
+    await tester.pumpAndSettle();
+
+    expect(find.text('...'), findsOneWidget);
+
+    //inference.prompt gets a result.
+    completer.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('The color of the sun is yellow'), findsOneWidget);
 
 
 
-  //  calloc.free(metrics);
-  //});
+
+    calloc.free(metrics);
+  });
+
 
 
 }

--- a/test/providers/text_inference_provider_test.dart
+++ b/test/providers/text_inference_provider_test.dart
@@ -60,4 +60,12 @@ void main() {
     expect(provider.messages[1].message, "The color of the sun is yellow");
     calloc.free(metrics);
   });
+
+  test('test inference provider dispose triggers close ', () async {
+      print("Testing...");
+    final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
+    provider.inference = inference;
+    provider.dispose();
+    verify(inference.close).called(1);
+  });
 }

--- a/test/providers/text_inference_provider_test.dart
+++ b/test/providers/text_inference_provider_test.dart
@@ -41,7 +41,6 @@ void main() {
   });
 
   test('test inference provider sets messages with question and answer ', () async {
-      print("Testing...");
     final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
 
     final completer = Completer<void>();
@@ -62,7 +61,6 @@ void main() {
   });
 
   test('test inference provider dispose triggers close ', () async {
-      print("Testing...");
     final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
     provider.inference = inference;
     provider.dispose();

--- a/test/providers/text_inference_provider_test.dart
+++ b/test/providers/text_inference_provider_test.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2024 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:async';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inference/interop/llm_inference.dart';
+import 'package:inference/interop/openvino_bindings.dart';
+import 'package:inference/providers/text_inference_provider.dart';
+
+import 'package:mocktail/mocktail.dart';
+
+import '../fixtures.dart';
+
+
+class MockLLMInference extends Mock implements LLMInference {}
+
+void main() {
+  late MockLLMInference inference;
+
+  setUpAll(() {
+    inference = MockLLMInference();
+  });
+
+  test('test inference provider sets interim message ', () async {
+    final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
+
+    final completer = Completer<void>();
+    final metrics = calloc<Metrics>();
+    when(() => inference.prompt(any(), any(), any())).thenAnswer((_) async {
+      await completer.future;
+      return ModelResponse("The color of the sun is yellow", metrics.ref);
+
+    });
+    provider.inference = inference;
+    provider.message("What is the color of the sun?");
+    expect(provider.interimResponse?.message, "...");
+    calloc.free(metrics);
+  });
+
+  test('test inference provider sets messages with question and answer ', () async {
+      print("Testing...");
+    final provider = TextInferenceProvider(largeLanguageModel(), "CPU");
+
+    final completer = Completer<void>();
+    final metrics = calloc<Metrics>();
+    when(() => inference.prompt(any(), any(), any())).thenAnswer((_) async {
+      await completer.future;
+      return ModelResponse("The color of the sun is yellow", metrics.ref);
+
+    });
+    provider.inference = inference;
+    final request = provider.message("What is the color of the sun?");
+    expect(provider.messages[0].message, "What is the color of the sun?");
+    completer.complete();
+    await request;
+    expect(provider.interimResponse, null);
+    expect(provider.messages[1].message, "The color of the sun is yellow");
+    calloc.free(metrics);
+  });
+}


### PR DESCRIPTION
This started off as work to add test coverage to text generation
However I was struggling with the layout a lot in llm. This is because the cpu has variable name length and in some cases is extremely long. 

I moved the options to an expander where we can add more options in the future like beam search:
![image](https://github.com/user-attachments/assets/1d595111-980a-49f7-a708-75d9f925a723)
