### PR TITLE
Fixes cache issue for OpenCV Linux

### DIFF
--- a/.github/workflows/build-linux-bindings.yml
+++ b/.github/workflows/build-linux-bindings.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           path: |
             /usr/local/include/opencv4
+            /usr/local/lib/cmake/opencv4
             /usr/local/lib/libopencv_*
           key: ${{ runner.os }}-opencv-${{ hashFiles('openvino_bindings/scripts/setup_opencv.sh') }}
 


### PR DESCRIPTION
Model API uses the cmake files for opencv.
This was not being cached though, meaning that when the cache was used then the runner would fail